### PR TITLE
Fix Resync Patreon button to properly call store method

### DIFF
--- a/web/pages/Settings/PatreonOauth.tsx
+++ b/web/pages/Settings/PatreonOauth.tsx
@@ -80,7 +80,7 @@ export const PatreonControls: Component = () => {
         </Show>
         <Show when={state.user?.patreon}>
           <div class="flex gap-2">
-            <Button class="w-fit" onClick={() => userStore.syncPatreonAccount(state)}>
+            <Button class="w-fit" onClick={() => userStore.syncPatreonAccount()}>
               Resync Patreon
             </Button>
             <Button class="w-fit" onClick={userStore.unverifyPatreon}>


### PR DESCRIPTION
The syncPatreonAccount is a generator function where the first parameter is auto-injected by the store framework. Passing the state object was treating it as the 'quiet' boolean parameter, preventing proper execution and toast notifications.

Now correctly calls the method without parameters, allowing the store to inject the current state and show success/error feedback to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)