### PR TITLE
fix: grant premium reliably on Patreon link/sync

### DIFF
--- a/common/types/schema.ts
+++ b/common/types/schema.ts
@@ -478,6 +478,7 @@ export namespace Patreon {
     attributes: {
       campaign_lifetime_support_cents: number
       campaign_entitled_amount_cents: number
+      currently_entitled_amount_cents: number
       is_gifted: boolean
       last_charge_date: string
       last_charge_status:

--- a/srv/api/user/auth.ts
+++ b/srv/api/user/auth.ts
@@ -158,14 +158,19 @@ export const remoteLogin = handle(async (req) => {
 export const resyncPatreon = handle(async (req) => {
   await patreon.revalidatePatron(req.userId)
   const next = await getSafeUserConfig(req.userId)
-  return next
+  // Re-issue the JWT so its embedded `premium` flag reflects the just-synced state.
+  const token = next ? await createAccessToken(next.username, next) : undefined
+  return { user: next, token }
 })
 
 export const verifyPatreonOauth = handle(async (req) => {
   const { body } = req
   assertValid({ code: 'string' }, body)
   await patreon.initialVerifyPatron(req.userId, body.code)
-  return { success: true }
+  const user = await getSafeUserConfig(req.userId)
+  // Re-issue the JWT so its embedded `premium` flag reflects the newly linked account.
+  const token = user ? await createAccessToken(user.username, user) : undefined
+  return { success: true, user, token }
 })
 
 export const unlinkPatreon = handle(async (req) => {

--- a/srv/api/user/patreon.ts
+++ b/srv/api/user/patreon.ts
@@ -74,29 +74,40 @@ async function identity(token: string) {
   }
 
   const user: Patreon.User = identity.body.data
-  const tiers: Patreon.Tier[] =
-    identity.body.included?.filter((obj: Patreon.Include) => {
-      if (obj.type !== 'tier') return false
-      return obj.relationships.campaign?.data?.id === config.patreon.campaign_id
-    }) || []
+  const included: Patreon.Include[] = identity.body.included || []
 
-  const tier = tiers.length
-    ? tiers.reduce((prev, curr) => {
-        if (!prev) return curr
-        return curr.attributes.amount_cents > prev.attributes.amount_cents ? curr : prev
-      })
-    : undefined
+  const campaignTiers = included.filter(
+    (obj): obj is Patreon.Tier =>
+      obj.type === 'tier' && obj.relationships.campaign?.data?.id === config.patreon.campaign_id
+  )
+  const campaignTierIds = new Set(campaignTiers.map((t) => t.id))
 
-  if (!tier) return { user }
+  /**
+   * Members don't carry a campaign relationship in this payload, so we identify the relevant
+   * member by their entitled tiers belonging to our campaign, then fall back to the active member.
+   * This keeps `member` (and therefore patron_status/next_charge_date) available even when tier
+   * mapping is imperfect.
+   */
+  const members = included.filter((obj): obj is Patreon.Member => obj.type === 'member')
+  const member =
+    members.find((m) =>
+      m.relationships.currently_entitled_tiers?.data?.some((d) => campaignTierIds.has(d.id))
+    ) ||
+    members.find((m) => m.attributes.patron_status === 'active_patron') ||
+    members[0]
 
-  const member = identity.body.included?.find((obj: Patreon.Include) => {
-    if (obj.type !== 'member') return false
-    const match = obj.relationships.currently_entitled_tiers?.data?.some((d) => d.id === tier.id)
-    return match
-  })
+  const entitledTierIds = new Set(
+    member?.relationships.currently_entitled_tiers?.data?.map((d) => d.id) || []
+  )
+  const tier =
+    pickHighestTier(campaignTiers.filter((t) => entitledTierIds.has(t.id))) ||
+    pickHighestTier(campaignTiers)
 
-  const contrib = tier.attributes.amount_cents
-  const sub = getPatronSubscriptionTier(contrib)
+  if (!tier && !member) return { user }
+
+  const contrib =
+    member?.attributes.currently_entitled_amount_cents || tier?.attributes.amount_cents || 0
+  const sub = contrib ? getPatronSubscriptionTier(contrib) : undefined
 
   return { tier, sub, user, member }
 }
@@ -154,8 +165,15 @@ async function revalidatePatron(userId: string | AppSchema.User) {
   return next
 }
 
+function pickHighestTier(tiers: Patreon.Tier[]) {
+  return tiers.reduce<Patreon.Tier | undefined>((prev, curr) => {
+    if (!prev) return curr
+    return curr.attributes.amount_cents > prev.attributes.amount_cents ? curr : prev
+  }, undefined)
+}
+
 function getPatronSubscriptionTier(contrib: number) {
-  const sub = getCachedTiers().reduce((prev, curr) => {
+  const sub = getCachedTiers().reduce<AppSchema.SubscriptionTier | undefined>((prev, curr) => {
     if (!curr.enabled || curr.deletedAt) return prev
     if (!curr.patreon?.tierId) return prev
     if (curr.patreon.cost > contrib) return prev
@@ -163,7 +181,7 @@ function getPatronSubscriptionTier(contrib: number) {
     if (!prev) return curr
     if (prev.patreon?.cost! > curr.patreon.cost) return prev
     return curr
-  })
+  }, undefined)
 
   return sub
 }
@@ -177,22 +195,33 @@ async function initialVerifyPatron(userId: string, code: string) {
     throw new StatusError(`This Patreon account is already attributed to another user`, 400)
   }
 
+  const expires = new Date(Date.now() + token.expires_in * 1000).toISOString()
+
+  /**
+   * Grant premium consistently with `revalidatePatron`: any active patron gets premium, not only
+   * those whose tier could be mapped to a local sub. Tier mapping can fail (campaign payload quirks,
+   * annual/custom tiers) and must not block premium for a paying patron.
+   */
+  const isActivePatron =
+    patron.member?.attributes.patron_status === 'active_patron' ||
+    (patron.sub?.level ?? 0) > 0
+  const premiumUntil = new Date(patron.member?.attributes.next_charge_date || expires).getTime()
+
   const next = await store.users.updateUser(userId, {
     patreon: {
       ...token,
-      expires: new Date(Date.now() + token.expires_in * 1000).toISOString(),
+      expires,
       user: patron.user,
       member: patron.member,
       tier: patron.tier,
       sub: patron.sub ? { tierId: patron.sub._id, level: patron.sub.level } : undefined,
     },
     patreonUserId: patron.user.id,
+    ...(isActivePatron ? { premium: true, premiumUntil } : {}),
   })
-  if (next?.premium === false && patron.sub?.level && patron.sub?.level > 0) {
+  if (next && isActivePatron) {
     next.premium = true
-    await store.users.updateUser(userId, {
-      premium: true,
-    })
+    next.premiumUntil = premiumUntil
   }
 
   return next

--- a/web/pages/Memory/Library.tsx
+++ b/web/pages/Memory/Library.tsx
@@ -52,7 +52,7 @@ const Library: Component = () => {
 
         <Match when={tabs.current() === 'Templates'}>
           <PromptTemplates />
-        </Match> */}
+        </Match>
 
         <Match when={tabs.current() === 'Embeddings'}>
           <EmbedsTab />

--- a/web/store/user.ts
+++ b/web/store/user.ts
@@ -447,6 +447,9 @@ export const userStore = createStore<UserState>(
     async verifyPatreon(_, body: any, onDone: (error?: any) => void) {
       const res = await api.post(`/user/verify/patreon`, body)
       if (res.result) {
+        // Refresh the JWT so premium-gated requests see the linked account immediately.
+        if (res.result.token) setAuth(res.result.token)
+        if (res.result.user) userStore.setState({ user: res.result.user })
         onDone()
         return
       }
@@ -474,16 +477,20 @@ export const userStore = createStore<UserState>(
     async *syncPatreonAccount({ sub: previous, tiers }, quiet?: boolean) {
       const res = await api.post('/user/resync/patreon')
 
-      if (res.result) {
-        yield { user: res.result }
+      // Refresh the JWT so premium-gated requests see the synced state immediately.
+      if (res.result?.token) setAuth(res.result.token)
+
+      const user = res.result?.user
+      if (user) {
+        yield { user }
       }
 
       if (quiet) return
 
-      if (res.result) {
+      if (user) {
         toastStore.success('Successfully updated Patreon information')
-        const sub = getUserSubscriptionTier(res.result, tiers, previous)
-        return { user: res.result, sub }
+        const sub = getUserSubscriptionTier(user, tiers, previous)
+        return { user, sub }
       }
 
       if (res.error) {


### PR DESCRIPTION
## Problem
Paid patrons could link or resync their Patreon account without receiving premium.

## Root causes
- **`initialVerifyPatron`** granted premium only when a local tier could be mapped (`patron.sub.level > 0`), while `revalidatePatron` granted it unconditionally. Patrons whose tier failed to map were linked but **not** premium.
- **Tier/member detection in `identity()`** was fragile: it dropped the member (and `patron_status`/`next_charge_date`) whenever tier mapping failed, and `getPatronSubscriptionTier` used `Array.reduce` with **no initial value**, risking a wrong/disabled tier or a throw on empty.
- **`isPremium`** relies on the JWT-embedded `premium` flag (120d expiry), but link/resync never re-issued the token — leaving it stale.

## Changes
- `identity()`: find the campaign member **independently** of tier mapping; derive contribution from `currently_entitled_amount_cents`.
- `getPatronSubscriptionTier()` / new `pickHighestTier()`: seed `reduce` with `undefined` and guard.
- `initialVerifyPatron()`: grant premium for any active patron, set `premiumUntil`, consistent with `revalidatePatron`.
- `resyncPatreon` / `verifyPatreonOauth`: re-issue the JWT; frontend stores `setAuth()` with the fresh token so premium applies immediately.
- Fix orphan JSX comment in `Library.tsx` that broke `tsc` typecheck.

## Verification
- `tsc -p srv.tsconfig.json --noEmit` — clean
- Server `.js` rebuilt
- No new errors introduced in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)