### PR TITLE
fix: derive Patreon sub level from actual pledge amount

### DIFF
--- a/common/util.ts
+++ b/common/util.ts
@@ -417,8 +417,14 @@ export function getPatreonEntitledTier(
   user: Pick<AppSchema.User, 'patreon'>,
   tiers: AppSchema.SubscriptionTier[]
 ) {
-  if (!user.patreon?.tier) return
-  const entitlement = user.patreon.tier.attributes?.amount_cents
+  if (!user.patreon) return
+
+  // Prefer the member's actual current pledge (`currently_entitled_amount_cents`) over the tier's
+  // nominal price. Tier mapping can be absent or mismatched (custom/annual pledges, payload quirks),
+  // and the pledge amount is what `identity()` uses to pick the matching local sub.
+  const entitlement =
+    user.patreon.member?.attributes?.currently_entitled_amount_cents ||
+    user.patreon.tier?.attributes?.amount_cents
   if (!entitlement) return
 
   return getPatreonEntitledTierByCost(entitlement, tiers)


### PR DESCRIPTION
Model eligibility (validateSubscription -> getUserSubTier -> getUserSubscriptionTier) computed the patron level via getPatreonEntitledTier, which bailed when user.patreon.tier was unset and otherwise keyed off the tier's nominal amount_cents. Linked patrons whose tier mapping was absent or mismatched (custom/annual pledges, payload quirks) fell back to the lowest paypal tier and hit 'Subscription tier insufficient' despite an active paid pledge.

Derive entitlement from the member's actual currently_entitled_amount_cents (the same value identity() uses to pick the local sub), falling back to the tier amount. Premium-only users still resolve via the paypal fallback.